### PR TITLE
Add logging and critical failure to the signing step

### DIFF
--- a/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
+++ b/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
@@ -67,14 +67,24 @@ shadowJar {
 
 signing {
     // Docs: https://github.com/wiremock/community/blob/main/infra/maven-central.md
+    def isPublishTask = gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish")
+    logger.info("Checking signing requirements: Version: " + version.toString() + ", Publish: " + isPublishTask)
+        
     required {
-        !version.toString().contains("SNAPSHOT") && (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))
+        !version.toString().contains("SNAPSHOT") && isPublishTask
     }
     def signingKey = providers.environmentVariable("OSSRH_GPG_SECRET_KEY").orElse("").get()
     def signingPassphrase = providers.environmentVariable("OSSRH_GPG_SECRET_KEY_PASSWORD").orElse("").get()
     if (!signingKey.isEmpty() && !signingPassphrase.isEmpty()) {
         useInMemoryPgpKeys(signingKey, signingPassphrase)
         sign(publishing.publications)
+    } else {
+        if (required) {
+            logger.error("Will not be signing the artifacts, no signing key or password specified via environment variables")
+            throw new GradleException("Cannot sign artifacts")
+        } else {
+            logger.info("Skipping signing of the artifacts, not required")
+        }
     }
 }
 
@@ -179,7 +189,7 @@ task checkReleasePreconditions {
     }
 }
 publish.dependsOn checkReleasePreconditions
-        publish.dependsOn 'signStandaloneJarPublication'
+publish.dependsOn 'signStandaloneJarPublication'
 publish.dependsOn 'signMavenJavaPublication'
 
 // FIXME: remove after https://github.com/gradle/gradle/issues/26091


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
