### PR TITLE
bump wiremock version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Features:
 - Gradle 8.x
 - Java 11 or 17
 
+## Wiremock dependency
+
+This extension has a bundled wiremock dependency. Depending on the wiremock features you're using
+in your plugin, this plugin needs to be updated accordingly:
+
+| Gradle Convention plugin version | Wiremock version |
+|----------------------------------|------------------|
+| 0.3.0+                           | 3.6.0            |
+| 0.1.0+                           | 3.3.1            |
+
+
 ## Usage
 
 ### Basic use

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ tasks {
 
 // default versions ---------------------------------------------------
 
-val wiremockVersion = "3.3.1"
+val wiremockVersion = "3.6.0"
 
 val basePackagePath = "org/wiremock/tools/gradle/plugins"
 val processResources by tasks.existing(ProcessResources::class)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.0
+version=0.3.0

--- a/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
+++ b/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
@@ -18,7 +18,7 @@ wrapper {
 
 project.ext {
     versions = [
-        wiremock  : '3.3.1',
+        wiremock  : '3.6.0',
         junit     : '5.10.1',
         assertj   : '3.24.2',
         restAssured: '5.3.2',
@@ -85,7 +85,7 @@ signing {
     // Docs: https://github.com/wiremock/community/blob/main/infra/maven-central.md
     def isPublishTask = gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish")
     logger.info("Checking signing requirements: Version: " + version.toString() + ", Publish: " + isPublishTask)
-        
+
     required {
         !version.toString().contains("SNAPSHOT") && isPublishTask
     }


### PR DESCRIPTION
Bump wiremock version to 3.6.0 to expose new extension functionalities and API changes.

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
