### PR TITLE
feat: make shadow JAR optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ developer.name=TODO WireMock Developer
 developer.email=noreply@wiremock.org
 ```
 
+It can be tweaked a bit more, with some optional properties:
+
+```properties
+useShadowJar = false # true by default, false will avoid creating the standalone JAR
+```
+
 Use the plugin in your `build.gradle.kts` file:
 
 ```kotlin

--- a/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
+++ b/src/main/groovy/org.wiremock.tools.gradle.wiremock-extension-convention.gradle
@@ -1,15 +1,25 @@
-plugins {
-    id 'java'
-    id 'java-library'
-    id 'idea'
-    id 'signing'
-    id 'maven-publish'
-    id 'com.github.johnrengelman.shadow'
-    id 'io.github.gradle-nexus.publish-plugin'
+def getGivenConfigConventional() {
+	def givenConfig = [
+		useShadowJar: project.getProperties().getOrDefault("useShadowJar", "true") == "true"
+	]
+	return givenConfig
 }
 
+logger.info("WireMock conventions given config: ${getGivenConfigConventional()}")
+
+
+project.plugins.apply 'java'
+project.plugins.apply 'java-library'
+project.plugins.apply 'idea'
+project.plugins.apply 'signing'
+project.plugins.apply 'maven-publish'
+if (getGivenConfigConventional().useShadowJar) {
+    project.plugins.apply "com.github.johnrengelman.shadow"
+}
+project.plugins.apply 'io.github.gradle-nexus.publish-plugin'
+
+
 group 'org.wiremock.extensions'
-//version gitVersion()
 
 wrapper {
     gradleVersion = '8.2.1'
@@ -42,43 +52,45 @@ jar {
     archiveBaseName.set("${baseArtifact}")
 }
 
-shadowJar {
-    archiveBaseName.set("${baseArtifact}-standalone")
-    archiveClassifier.set('')
-    configurations = [
-        project.configurations.runtimeClasspath,
-        project.configurations.standaloneOnly
-    ]
+if (getGivenConfigConventional().useShadowJar) {
+    shadowJar {
+        archiveBaseName.set("${baseArtifact}-standalone")
+        archiveClassifier.set('')
+        configurations = [
+            project.configurations.runtimeClasspath,
+            project.configurations.standaloneOnly
+        ]
 
-    relocate 'org.mortbay', 'wiremock.org.mortbay'
-    relocate 'org.eclipse', 'wiremock.org.eclipse'
-    relocate 'org.codehaus', 'wiremock.org.codehaus'
-    relocate 'com.google', 'wiremock.com.google'
-    relocate 'com.google.thirdparty', 'wiremock.com.google.thirdparty'
-    relocate 'com.fasterxml.jackson', 'wiremock.com.fasterxml.jackson'
-    relocate 'org.apache', 'wiremock.org.apache'
-    relocate 'org.xmlunit', 'wiremock.org.xmlunit'
-    relocate 'org.hamcrest', 'wiremock.org.hamcrest'
-    relocate 'org.skyscreamer', 'wiremock.org.skyscreamer'
-    relocate 'org.json', 'wiremock.org.json'
-    relocate 'net.minidev', 'wiremock.net.minidev'
-    relocate 'com.jayway', 'wiremock.com.jayway'
-    relocate 'org.objectweb', 'wiremock.org.objectweb'
-    relocate 'org.custommonkey', 'wiremock.org.custommonkey'
-    relocate 'net.javacrumbs', 'wiremock.net.javacrumbs'
-    relocate 'net.sf', 'wiremock.net.sf'
-    relocate 'com.github.jknack', 'wiremock.com.github.jknack'
-    relocate 'org.antlr', 'wiremock.org.antlr'
-    relocate 'jakarta.servlet', 'wiremock.jakarta.servlet'
-    relocate 'org.checkerframework', 'wiremock.org.checkerframework'
-    relocate 'org.hamcrest', 'wiremock.org.hamcrest'
-    relocate 'org.slf4j', 'wiremock.org.slf4j'
-    relocate 'joptsimple', 'wiremock.joptsimple'
-    relocate 'org.yaml', 'wiremock.org.yaml'
-    relocate 'com.ethlo', 'wiremock.com.ethlo'
-    relocate 'com.networknt', 'wiremock.com.networknt'
+        relocate 'org.mortbay', 'wiremock.org.mortbay'
+        relocate 'org.eclipse', 'wiremock.org.eclipse'
+        relocate 'org.codehaus', 'wiremock.org.codehaus'
+        relocate 'com.google', 'wiremock.com.google'
+        relocate 'com.google.thirdparty', 'wiremock.com.google.thirdparty'
+        relocate 'com.fasterxml.jackson', 'wiremock.com.fasterxml.jackson'
+        relocate 'org.apache', 'wiremock.org.apache'
+        relocate 'org.xmlunit', 'wiremock.org.xmlunit'
+        relocate 'org.hamcrest', 'wiremock.org.hamcrest'
+        relocate 'org.skyscreamer', 'wiremock.org.skyscreamer'
+        relocate 'org.json', 'wiremock.org.json'
+        relocate 'net.minidev', 'wiremock.net.minidev'
+        relocate 'com.jayway', 'wiremock.com.jayway'
+        relocate 'org.objectweb', 'wiremock.org.objectweb'
+        relocate 'org.custommonkey', 'wiremock.org.custommonkey'
+        relocate 'net.javacrumbs', 'wiremock.net.javacrumbs'
+        relocate 'net.sf', 'wiremock.net.sf'
+        relocate 'com.github.jknack', 'wiremock.com.github.jknack'
+        relocate 'org.antlr', 'wiremock.org.antlr'
+        relocate 'jakarta.servlet', 'wiremock.jakarta.servlet'
+        relocate 'org.checkerframework', 'wiremock.org.checkerframework'
+        relocate 'org.hamcrest', 'wiremock.org.hamcrest'
+        relocate 'org.slf4j', 'wiremock.org.slf4j'
+        relocate 'joptsimple', 'wiremock.joptsimple'
+        relocate 'org.yaml', 'wiremock.org.yaml'
+        relocate 'com.ethlo', 'wiremock.com.ethlo'
+        relocate 'com.networknt', 'wiremock.com.networknt'
 
-    mergeServiceFiles()
+        mergeServiceFiles()
+    }
 }
 
 signing {
@@ -116,9 +128,12 @@ publishing {
         }
     }
 
-    getComponents().withType(AdhocComponentWithVariants).each { c ->
-        c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
-            skip()
+
+    if (getGivenConfigConventional().useShadowJar) {
+        getComponents().withType(AdhocComponentWithVariants).each { c ->
+            c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
+                skip()
+            }
         }
     }
 
@@ -160,7 +175,10 @@ publishing {
         standaloneJar(MavenPublication) { publication ->
             artifactId = "${baseArtifact}-standalone"
 
-            project.shadow.component(publication)
+
+            if (getGivenConfigConventional().useShadowJar) {
+                project.shadow.component(publication)
+            }
 
             artifact sourcesJar
                     artifact javadocJar
@@ -220,7 +238,9 @@ repositories {
 }
 
 dependencies {
-    shadow("org.wiremock:wiremock:${versions.wiremock}")
+    if (getGivenConfigConventional().useShadowJar) {
+        shadow("org.wiremock:wiremock:${versions.wiremock}")
+    }
 
     testImplementation("org.wiremock:wiremock:${versions.wiremock}")
     testImplementation(platform("org.junit:junit-bom:${versions.junit}"))
@@ -244,8 +264,13 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
-assemble.dependsOn jar, shadowJar
-test.dependsOn shadowJar
+
+assemble.dependsOn jar
+
+if (getGivenConfigConventional().useShadowJar) {
+    assemble.dependsOn shadowJar
+    test.dependsOn shadowJar
+}
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
I just got [wiremock-spring-boot](https://github.com/wiremock/wiremock-spring-boot) moved to the WireMock organization. I'd like to use this plugin.

The project is a JUnit 5 extension and I don't feel it makes sense to provide a standalone JAR. Would like to opt out of it.

If this is way of making it configurable is ok with you, perhaps we may want to have `groupId` configurable also. If you don't want junit 5 extensions in `org.wiremock.extensions`.

Also setting the version from [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) could be added as an optional feature:

```groovy
def bumpVersionTo(version) {
  def propertyFile = new File("$projectDir/gradle.properties")
  def gradleProps = new Properties()
  propertyFile.withReader { gradleProps.load(it) }
  def currentVersion = gradleProps.getProperty("version")
  if (currentVersion == version) {
    logger.lifecycle("Version not changed (${currentVersion})")
  } else {
    logger.lifecycle("Version changed (${currentVersion} -> ${version})")
    gradleProps.setProperty('version', version)
    propertyFile.withWriter { gradleProps.store(it, null) }
  }
}

task setConventionalVersion() {
  doFirst {
    def nextVersion = se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder()
        .withFromRepo(file('.'))
        .withSemanticMajorVersionPattern("^[Bb]reak")
        .withSemanticMinorVersionPattern("^[Ff]eat")
        .getNextSemanticVersion()
        .getVersion();
    def nextSnapshot = "${nextVersion}-SNAPSHOT"
    bumpVersionTo(nextSnapshot)
  }
}
build.dependsOn setConventionalVersion
```

## References

- https://github.com/wiremock/wiremock-spring-boot/issues/44

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
