### PR TITLE
Switch the target Nexus URL to OSSRH Staging API by default

### DIFF
--- a/src/main/groovy/org.wiremock.tools.gradle.publishing.gradle
+++ b/src/main/groovy/org.wiremock.tools.gradle.publishing.gradle
@@ -208,6 +208,7 @@ nexusPublishing {
             // TODO: allow configuring destinations for oss1
             // nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
             // snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
             def envUsername = providers.environmentVariable("OSSRH_USERNAME").orElse("").get()
             def envPassword = providers.environmentVariable("OSSRH_TOKEN").orElse("").get()
             if (!envUsername.isEmpty() && !envPassword.isEmpty()) {


### PR DESCRIPTION
I think this should fix the error I get in wiremock-spring-boot:

```
> Task :initializeSonatypeStagingRepository FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to load staging profiles, server at https://oss.sonatype.org/service/local/ responded with status code 403, body: <html>
    <head>
      <title>403 - Forbidden</title>
      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
  
      <link rel="icon" type="image/png" href="https://oss.sonatype.org/favicon.png">
      <!--[if IE]>
      <link rel="SHORTCUT ICON" href="https://oss.sonatype.org/favicon.ico"/>
      <![endif]-->
  
      <link rel="stylesheet" href="https://oss.sonatype.org/static/css/Sonatype-content.css?2.15.2-03" type="text/css" media="screen" title="no title" charset="utf-8">
    </head>
    <body>
      <h1>403 - Forbidden</h1>
      <p>Forbidden</p>
    </body>
  </html>
```